### PR TITLE
Fix for parsing through stops in IFF

### DIFF
--- a/iff/parser.py
+++ b/iff/parser.py
@@ -84,7 +84,7 @@ def parse_timetables(delivery):
 			current_record['stop'].append({'station': s_stationshort, 'index': s_index, 'arrivaltime': both, 'departuretime': both})
 		elif x[0] == ';':
 			s_index += 1
-			s_stationshort = x[1:].split(',')
+			s_stationshort = x[1:]
 			s_stationshort = s_stationshort.strip()
 			current_record['stop'].append({'station': s_stationshort, 'index': s_index, 'arrivaltime': None, 'departuretime': None})
 		elif x[0] == '+':


### PR DESCRIPTION
NS gaat een nieuw IFF formaat introduceren waarin onder meer passagestations zijn opgenomen. In de IFF parser worden deze stations niet goed verwerkt, regels met een passagestation geven de volgende fout:

```
AttributeError: 'list' object has no attribute 'strip'
```

Deze PR fixt deze bug en verwerkt passagestations correct.
